### PR TITLE
Don't recalculate number of cells past boot

### DIFF
--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -189,6 +189,13 @@ const AP_Param::GroupInfo AP_OSD::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("_EFF_UNIT", 23, AP_OSD, efficiency_unit_base, AP_OSD::EFF_UNIT_BASE_MAH),
 
+    // @Param: _W_AVGVOLT
+    // @DisplayName: AVGVOLT warn level
+    // @Description: Set level at which AVGVOLT item will flash
+    // @Range: 0 100
+    // @User: Standard
+    AP_GROUPINFO("_W_AVGVOLT", 24, AP_OSD, warn_avgvolt, 3.6f),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -339,7 +339,6 @@ void AP_OSD::stats()
     max_alt_m = fmaxf(max_alt_m, alt);
     // maximum current
     AP_BattMonitor &battery = AP::battery();
-    if (this->num_cells == 0) this->num_cells = (uint8_t)((battery.voltage()/4.3f) + 1);
     float amps;
     if (battery.current_amps(amps)) {
         max_current_a = fmaxf(max_current_a, amps);
@@ -362,6 +361,12 @@ void AP_OSD::update_current_screen()
         }
         was_armed = false;
     }
+
+    AP_BattMonitor &battery = AP::battery();
+    uint8_t cell_calculation = (uint8_t)((battery.voltage()/4.3f) + 1);
+    // This is because we can calculate the wrong number of cells if voltage is
+    // 0 at boot. We always use the maximum number of cells calculated.
+    if (cell_calculation > num_cells) num_cells = cell_calculation;
 
     // Switch on failsafe event
     if (AP_Notify::flags.failsafe_radio || AP_Notify::flags.failsafe_battery) {

--- a/libraries/AP_OSD/AP_OSD.cpp
+++ b/libraries/AP_OSD/AP_OSD.cpp
@@ -339,6 +339,7 @@ void AP_OSD::stats()
     max_alt_m = fmaxf(max_alt_m, alt);
     // maximum current
     AP_BattMonitor &battery = AP::battery();
+    if (this->num_cells == 0) this->num_cells = (uint8_t)((battery.voltage()/4.3f) + 1);
     float amps;
     if (battery.current_amps(amps)) {
         max_current_a = fmaxf(max_current_a, amps);

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -135,6 +135,7 @@ private:
 
     AP_OSD_Setting altitude{true, 23, 8};
     AP_OSD_Setting bat_volt{true, 24, 1};
+    AP_OSD_Setting avgvolt{true, 1, 1};
     AP_OSD_Setting rssi{true, 1, 1};
     AP_OSD_Setting current{true, 25, 2};
     AP_OSD_Setting batused{true, 23, 3};
@@ -197,6 +198,7 @@ private:
 
     void draw_altitude(uint8_t x, uint8_t y);
     void draw_bat_volt(uint8_t x, uint8_t y);
+    void draw_avgvolt(uint8_t x, uint8_t y);
     void draw_rssi(uint8_t x, uint8_t y);
     void draw_current(uint8_t x, uint8_t y);
     void draw_current(uint8_t instance, uint8_t x, uint8_t y);
@@ -451,6 +453,7 @@ public:
 
     AP_Int8 warn_rssi;
     AP_Int8 warn_nsat;
+    AP_Float warn_avgvolt;
     AP_Float warn_batvolt;
     AP_Float warn_bat2volt;
     AP_Int8 msgtime_s;

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -547,7 +547,7 @@ private:
     bool was_armed;
     bool was_failsafe;
     bool _disable;
-    uint8_t num_cells = 0;
+    uint8_t num_cells = 1;
 
     uint32_t last_update_ms;
     float last_distance_m;

--- a/libraries/AP_OSD/AP_OSD.h
+++ b/libraries/AP_OSD/AP_OSD.h
@@ -547,6 +547,7 @@ private:
     bool was_armed;
     bool was_failsafe;
     bool _disable;
+    uint8_t num_cells = 0;
 
     uint32_t last_update_ms;
     float last_distance_m;

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -927,6 +927,22 @@ const AP_Param::GroupInfo AP_OSD_Screen::var_info[] = {
     // @Range: 0 15
     AP_SUBGROUPINFO(energy, "ENERGY", 56, AP_OSD_Screen, AP_OSD_Setting),
 
+    // @Param: AVGVOLT_EN
+    // @DisplayName: AVGVOLT_EN
+    // @Description: Displays average cell voltage
+    // @Values: 0:Disabled,1:Enabled
+
+    // @Param: AVGVOLT_X
+    // @DisplayName: AVGVOLT_X
+    // @Description: Horizontal position on screen
+    // @Range: 0 29
+
+    // @Param: AVGVOLT_Y
+    // @DisplayName: AVGVOLT_Y
+    // @Description: Vertical position on screen
+    // @Range: 0 15
+    AP_SUBGROUPINFO(avgvolt, "AVGVOLT", 57, AP_OSD_Screen, AP_OSD_Setting),
+
     AP_GROUPEND
 };
 
@@ -1150,6 +1166,17 @@ void AP_OSD_Screen::draw_altitude(uint8_t x, uint8_t y)
     ahrs.get_relative_position_D_home(alt);
     alt = -alt;
     backend->write(x, y, false, "%4d%c", (int)u_scale(ALTITUDE, alt), u_icon(ALTITUDE));
+}
+
+void AP_OSD_Screen::draw_avgvolt(uint8_t x, uint8_t y)
+{
+    AP_BattMonitor &battery = AP::battery();
+    uint8_t pct = battery.capacity_remaining_pct();
+    uint8_t p = (100 - pct) / 16.6;
+    float v = battery.voltage();
+    uint8_t num_cells = (uint8_t)((v/4.3) + 1);
+    double voltage = (double)v/num_cells;
+    backend->write(x,y, voltage < osd->warn_avgvolt, "%c%2.1f%c", SYM_BATT_FULL + p, voltage, SYM_VOLT);
 }
 
 void AP_OSD_Screen::draw_bat_volt(uint8_t x, uint8_t y)
@@ -1936,6 +1963,7 @@ void AP_OSD_Screen::draw(void)
     DRAW_SETTING(waypoint);
     DRAW_SETTING(xtrack_error);
     DRAW_SETTING(bat_volt);
+    DRAW_SETTING(avgvolt);
     DRAW_SETTING(bat2_vlt);
     DRAW_SETTING(rssi);
     DRAW_SETTING(current);

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -1176,7 +1176,7 @@ void AP_OSD_Screen::draw_avgvolt(uint8_t x, uint8_t y)
     float v = battery.voltage();
     uint8_t num_cells = (uint8_t)((v/4.3f) + 1);
     float voltage = v/num_cells;
-    backend->write(x,y, voltage < osd->warn_avgvolt, "%c%2.1f%c", SYM_BATT_FULL + p, voltage, SYM_VOLT);
+    backend->write(x,y, voltage < osd->warn_avgvolt, "%c%1.2f%c", SYM_BATT_FULL + p, voltage, SYM_VOLT);
 }
 
 void AP_OSD_Screen::draw_bat_volt(uint8_t x, uint8_t y)

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -1174,8 +1174,7 @@ void AP_OSD_Screen::draw_avgvolt(uint8_t x, uint8_t y)
     uint8_t pct = battery.capacity_remaining_pct();
     uint8_t p = (100 - pct) / 16.6;
     float v = battery.voltage();
-    uint8_t num_cells = (uint8_t)((v/4.3f) + 1);
-    float voltage = v/num_cells;
+    float voltage = v/osd->num_cells;
     backend->write(x,y, voltage < osd->warn_avgvolt, "%c%1.2f%c", SYM_BATT_FULL + p, voltage, SYM_VOLT);
 }
 

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -1174,8 +1174,8 @@ void AP_OSD_Screen::draw_avgvolt(uint8_t x, uint8_t y)
     uint8_t pct = battery.capacity_remaining_pct();
     uint8_t p = (100 - pct) / 16.6;
     float v = battery.voltage();
-    uint8_t num_cells = (uint8_t)((v/4.3) + 1);
-    double voltage = (double)v/num_cells;
+    uint8_t num_cells = (uint8_t)((v/4.3f) + 1);
+    float voltage = v/num_cells;
     backend->write(x,y, voltage < osd->warn_avgvolt, "%c%2.1f%c", SYM_BATT_FULL + p, voltage, SYM_VOLT);
 }
 


### PR DESCRIPTION
Currently, the code recalculates number of battery cells continuously, so a very discharged battery might look like a fully charged lower-celled one. This PR makes it so that cells are only calculated at boot, reducing that risk.